### PR TITLE
FIx application icon

### DIFF
--- a/src/assets/no-app-icon.svg
+++ b/src/assets/no-app-icon.svg
@@ -1,63 +1,50 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
-        "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg xmlns="http://www.w3.org/2000/svg"
-     xmlns:xlink="http://www.w3.org/1999/xlink"
      version="1.1"
      width="900"
      height="900"
      viewBox="1709.13 1602.51 900 900"
      xml:space="preserve"
-     preserveAspectRatio="xMidYMid slice">
-    <rect x="0" y="0" width="100%" height="100%" fill="transparent" />
+     preserveAspectRatio="xMidYMid slice"
+>
+  <rect x="0" y="0" width="100%" height="100%" fill="transparent" />
 
-    <g transform="matrix(1 0 0 1 450 450)" id="background-layer">
-    <rect x="-450" y="-450" width="900" height="900"
-          style="fill: rgb(255,255,255); visibility: hidden;" />
+  <g transform="matrix(1 0 0 1 450 450)" id="background-layer">
+    <rect x="-450" y="-450" width="900" height="900" style="fill: rgb(255,255,255); visibility: hidden;" />
   </g>
 
-    <g transform="matrix(12.2 0 0 12.2 2160.42 2051.46)" id="base-square">
-    <rect x="-33.085" y="-33.085" width="66.17" height="66.17"
-          style="fill: rgb(35,44,42); stroke-width: 1;" />
+  <g transform="matrix(12.2 0 0 12.2 2160.42 2051.46)" id="base-square">
+    <rect x="-33.085" y="-33.085" width="66.17" height="66.17" style="fill: rgb(35,44,42); stroke-width: 1;" />
   </g>
 
-    <g transform="matrix(7.2 0 0 7.2 2160.42 2051.79)" id="center-circle">
-    <circle cx="0" cy="0" r="35"
-            style="fill: rgb(35,44,42); stroke: rgb(68,68,68); stroke-width: 1;" />
+  <g transform="matrix(7.2 0 0 7.2 2160.42 2051.79)" id="center-circle">
+    <circle cx="0" cy="0" r="35" style="fill: rgb(35,44,42); stroke: rgb(68,68,68); stroke-width: 1;" />
   </g>
 
-    <g transform="matrix(-10.74 -10.74 -0.05 0.05 2160.33 2052.81)" id="shape-1">
-    <rect x="-17.46" y="-19.415" width="34.92" height="38.83"
-          style="fill: rgb(68,68,68); stroke: rgb(68,68,68); stroke-width: 40;" />
+  <g transform="matrix(-10.74 -10.74 -0.05 0.05 2160.33 2052.81)" id="shape-1">
+    <rect x="-17.46" y="-19.415" width="34.92" height="38.83" style="fill: rgb(68,68,68); stroke: rgb(68,68,68); stroke-width: 40;" />
   </g>
 
-    <g transform="matrix(10.71 -10.71 -0.05 -0.05 2160.62 2052.92)" id="shape-2">
-    <rect x="-17.46" y="-19.415" width="34.92" height="38.83"
-          style="fill: rgb(68,68,68); stroke: rgb(68,68,68); stroke-width: 40;" />
+  <g transform="matrix(10.71 -10.71 -0.05 -0.05 2160.62 2052.92)" id="shape-2">
+    <rect x="-17.46" y="-19.415" width="34.92" height="38.83" style="fill: rgb(68,68,68); stroke: rgb(68,68,68); stroke-width: 40;" />
   </g>
 
-    <g transform="matrix(10.69 0 0 -0.07 2160.36 2053.16)" id="shape-3">
-    <rect x="-17.46" y="-19.415" width="34.92" height="38.83"
-          style="fill: rgb(68,68,68); stroke: rgb(68,68,68); stroke-width: 40;" />
+  <g transform="matrix(10.69 0 0 -0.07 2160.36 2053.16)" id="shape-3">
+    <rect x="-17.46" y="-19.415" width="34.92" height="38.83" style="fill: rgb(68,68,68); stroke: rgb(68,68,68); stroke-width: 40;" />
   </g>
 
-    <g transform="matrix(0 -10.69 -0.07 0 1896.9 2052.81)" id="shape-4">
-    <rect x="-17.46" y="-19.415" width="34.92" height="38.83"
-          style="fill: rgb(68,68,68); stroke: rgb(68,68,68); stroke-width: 40;" />
+  <g transform="matrix(0 -10.69 -0.07 0 1896.9 2052.81)" id="shape-4">
+    <rect x="-17.46" y="-19.415" width="34.92" height="38.83" style="fill: rgb(68,68,68); stroke: rgb(68,68,68); stroke-width: 40;" />
   </g>
 
-    <g transform="matrix(0 -10.69 -0.07 0 2423.68 2053.49)" id="shape-5">
-    <rect x="-17.46" y="-19.415" width="34.92" height="38.83"
-          style="fill: rgb(68,68,68); stroke: rgb(68,68,68); stroke-width: 40;" />
+  <g transform="matrix(0 -10.69 -0.07 0 2423.68 2053.49)" id="shape-5">
+    <rect x="-17.46" y="-19.415" width="34.92" height="38.83" style="fill: rgb(68,68,68); stroke: rgb(68,68,68); stroke-width: 40;" />
   </g>
 
-    <g transform="matrix(-10.69 0 0 0.07 2160.38 1790.29)" id="shape-6">
-    <rect x="-17.46" y="-19.415" width="34.92" height="38.83"
-          style="fill: rgb(68,68,68); stroke: rgb(68,68,68); stroke-width: 40;" />
+  <g transform="matrix(-10.69 0 0 0.07 2160.38 1790.29)" id="shape-6">
+    <rect x="-17.46" y="-19.415" width="34.92" height="38.83" style="fill: rgb(68,68,68); stroke: rgb(68,68,68); stroke-width: 40;" />
   </g>
 
-    <g transform="matrix(-10.68 0 0 0.07 2160.42 2317.82)" id="shape-7">
-    <rect x="-17.46" y="-19.415" width="34.92" height="38.83"
-          style="fill: rgb(68,68,68); stroke: rgb(68,68,68); stroke-width: 40;" />
+  <g transform="matrix(-10.68 0 0 0.07 2160.42 2317.82)" id="shape-7">
+    <rect x="-17.46" y="-19.415" width="34.92" height="38.83" style="fill: rgb(68,68,68); stroke: rgb(68,68,68); stroke-width: 40;" />
   </g>
 </svg>

--- a/src/assets/no-app-icon.svg
+++ b/src/assets/no-app-icon.svg
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+        "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:xlink="http://www.w3.org/1999/xlink"
+     version="1.1"
+     width="900"
+     height="900"
+     viewBox="1709.13 1602.51 900 900"
+     xml:space="preserve"
+     preserveAspectRatio="xMidYMid slice">
+    <rect x="0" y="0" width="100%" height="100%" fill="transparent" />
+
+    <g transform="matrix(1 0 0 1 450 450)" id="background-layer">
+    <rect x="-450" y="-450" width="900" height="900"
+          style="fill: rgb(255,255,255); visibility: hidden;" />
+  </g>
+
+    <g transform="matrix(12.2 0 0 12.2 2160.42 2051.46)" id="base-square">
+    <rect x="-33.085" y="-33.085" width="66.17" height="66.17"
+          style="fill: rgb(35,44,42); stroke-width: 1;" />
+  </g>
+
+    <g transform="matrix(7.2 0 0 7.2 2160.42 2051.79)" id="center-circle">
+    <circle cx="0" cy="0" r="35"
+            style="fill: rgb(35,44,42); stroke: rgb(68,68,68); stroke-width: 1;" />
+  </g>
+
+    <g transform="matrix(-10.74 -10.74 -0.05 0.05 2160.33 2052.81)" id="shape-1">
+    <rect x="-17.46" y="-19.415" width="34.92" height="38.83"
+          style="fill: rgb(68,68,68); stroke: rgb(68,68,68); stroke-width: 40;" />
+  </g>
+
+    <g transform="matrix(10.71 -10.71 -0.05 -0.05 2160.62 2052.92)" id="shape-2">
+    <rect x="-17.46" y="-19.415" width="34.92" height="38.83"
+          style="fill: rgb(68,68,68); stroke: rgb(68,68,68); stroke-width: 40;" />
+  </g>
+
+    <g transform="matrix(10.69 0 0 -0.07 2160.36 2053.16)" id="shape-3">
+    <rect x="-17.46" y="-19.415" width="34.92" height="38.83"
+          style="fill: rgb(68,68,68); stroke: rgb(68,68,68); stroke-width: 40;" />
+  </g>
+
+    <g transform="matrix(0 -10.69 -0.07 0 1896.9 2052.81)" id="shape-4">
+    <rect x="-17.46" y="-19.415" width="34.92" height="38.83"
+          style="fill: rgb(68,68,68); stroke: rgb(68,68,68); stroke-width: 40;" />
+  </g>
+
+    <g transform="matrix(0 -10.69 -0.07 0 2423.68 2053.49)" id="shape-5">
+    <rect x="-17.46" y="-19.415" width="34.92" height="38.83"
+          style="fill: rgb(68,68,68); stroke: rgb(68,68,68); stroke-width: 40;" />
+  </g>
+
+    <g transform="matrix(-10.69 0 0 0.07 2160.38 1790.29)" id="shape-6">
+    <rect x="-17.46" y="-19.415" width="34.92" height="38.83"
+          style="fill: rgb(68,68,68); stroke: rgb(68,68,68); stroke-width: 40;" />
+  </g>
+
+    <g transform="matrix(-10.68 0 0 0.07 2160.42 2317.82)" id="shape-7">
+    <rect x="-17.46" y="-19.415" width="34.92" height="38.83"
+          style="fill: rgb(68,68,68); stroke: rgb(68,68,68); stroke-width: 40;" />
+  </g>
+</svg>

--- a/src/assets/no-app-icon.svg
+++ b/src/assets/no-app-icon.svg
@@ -1,50 +1,34 @@
-<svg xmlns="http://www.w3.org/2000/svg"
-     version="1.1"
-     width="900"
-     height="900"
-     viewBox="1709.13 1602.51 900 900"
-     xml:space="preserve"
-     preserveAspectRatio="xMidYMid slice"
->
-  <rect x="0" y="0" width="100%" height="100%" fill="transparent" />
-
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="900" height="900" viewBox="1757.501 1648.178 806.546 806.694" preserveAspectRatio="xMidYMid slice">
+  <rect x="0" y="0" width="100%" height="100%" fill="transparent"/>
   <g transform="matrix(1 0 0 1 450 450)" id="background-layer">
-    <rect x="-450" y="-450" width="900" height="900" style="fill: rgb(255,255,255); visibility: hidden;" />
+    <rect x="-450" y="-450" width="900" height="900" style="fill: rgb(255,255,255); visibility: hidden;"/>
   </g>
-
   <g transform="matrix(12.2 0 0 12.2 2160.42 2051.46)" id="base-square">
-    <rect x="-33.085" y="-33.085" width="66.17" height="66.17" style="fill: rgb(35,44,42); stroke-width: 1;" />
+    <rect x="-33.085" y="-33.085" width="66.17" height="66.17" style="fill: rgb(35,44,42); stroke-width: 1;"/>
   </g>
-
   <g transform="matrix(7.2 0 0 7.2 2160.42 2051.79)" id="center-circle">
-    <circle cx="0" cy="0" r="35" style="fill: rgb(35,44,42); stroke: rgb(68,68,68); stroke-width: 1;" />
+    <circle cx="0" cy="0" r="35" style="fill: rgb(35,44,42); stroke: rgb(68,68,68); stroke-width: 1;"/>
   </g>
-
   <g transform="matrix(-10.74 -10.74 -0.05 0.05 2160.33 2052.81)" id="shape-1">
-    <rect x="-17.46" y="-19.415" width="34.92" height="38.83" style="fill: rgb(68,68,68); stroke: rgb(68,68,68); stroke-width: 40;" />
+    <rect x="-17.46" y="-19.415" width="34.92" height="38.83" style="fill: rgb(68,68,68); stroke: rgb(68,68,68); stroke-width: 40;"/>
   </g>
-
   <g transform="matrix(10.71 -10.71 -0.05 -0.05 2160.62 2052.92)" id="shape-2">
-    <rect x="-17.46" y="-19.415" width="34.92" height="38.83" style="fill: rgb(68,68,68); stroke: rgb(68,68,68); stroke-width: 40;" />
+    <rect x="-17.46" y="-19.415" width="34.92" height="38.83" style="fill: rgb(68,68,68); stroke: rgb(68,68,68); stroke-width: 40;"/>
   </g>
-
   <g transform="matrix(10.69 0 0 -0.07 2160.36 2053.16)" id="shape-3">
-    <rect x="-17.46" y="-19.415" width="34.92" height="38.83" style="fill: rgb(68,68,68); stroke: rgb(68,68,68); stroke-width: 40;" />
+    <rect x="-17.46" y="-19.415" width="34.92" height="38.83" style="fill: rgb(68,68,68); stroke: rgb(68,68,68); stroke-width: 40;"/>
   </g>
-
   <g transform="matrix(0 -10.69 -0.07 0 1896.9 2052.81)" id="shape-4">
-    <rect x="-17.46" y="-19.415" width="34.92" height="38.83" style="fill: rgb(68,68,68); stroke: rgb(68,68,68); stroke-width: 40;" />
+    <rect x="-17.46" y="-19.415" width="34.92" height="38.83" style="fill: rgb(68,68,68); stroke: rgb(68,68,68); stroke-width: 40;"/>
   </g>
-
   <g transform="matrix(0 -10.69 -0.07 0 2423.68 2053.49)" id="shape-5">
-    <rect x="-17.46" y="-19.415" width="34.92" height="38.83" style="fill: rgb(68,68,68); stroke: rgb(68,68,68); stroke-width: 40;" />
+    <rect x="-17.46" y="-19.415" width="34.92" height="38.83" style="fill: rgb(68,68,68); stroke: rgb(68,68,68); stroke-width: 40;"/>
   </g>
-
   <g transform="matrix(-10.69 0 0 0.07 2160.38 1790.29)" id="shape-6">
-    <rect x="-17.46" y="-19.415" width="34.92" height="38.83" style="fill: rgb(68,68,68); stroke: rgb(68,68,68); stroke-width: 40;" />
+    <rect x="-17.46" y="-19.415" width="34.92" height="38.83" style="fill: rgb(68,68,68); stroke: rgb(68,68,68); stroke-width: 40;"/>
   </g>
-
-  <g transform="matrix(-10.68 0 0 0.07 2160.42 2317.82)" id="shape-7">
-    <rect x="-17.46" y="-19.415" width="34.92" height="38.83" style="fill: rgb(68,68,68); stroke: rgb(68,68,68); stroke-width: 40;" />
+  <g transform="matrix(-10.68, 0, 0, 0.07, 2160.419922, 2313.820068)" id="shape-7">
+    <rect x="-17.46" y="-19.415" width="34.92" height="38.83" style="fill: rgb(68,68,68); stroke: rgb(68,68,68); stroke-width: 40;"/>
   </g>
 </svg>

--- a/src/internal/components/push/platforms/android/app-ui/RateNotification/RateNotification.tsx
+++ b/src/internal/components/push/platforms/android/app-ui/RateNotification/RateNotification.tsx
@@ -5,22 +5,16 @@ import { NavigationBar } from '../NavigationBar/NavigationBar';
 
 import './RateNotification.css';
 
-export function RateNotification({
-  notification,
-}: RateNotificationProps) {
+export function RateNotification({ notification }: RateNotificationProps) {
   const application = useApplication();
 
-  // TODO: the package name should be URL encoded.
+  const url = new URL('/store/apps/details', 'https://play.google.com');
+  url.searchParams.set('id', application.androidPackageName || '');
 
   return (
     <div data-testid="android-app-ui-rate-notification">
       <NavigationBar title={notification.title || application.name} showOptions={false} />
-      <Webshot
-        url={`https://play.google.com/store/apps/details?id=${application.androidPackageName}&hl=en`}
-        platform={'Android'}
-        width={338}
-        height={570}
-      />
+      <Webshot url={url.toString()} platform={'Android'} width={338} height={570} />
     </div>
   );
 }

--- a/src/internal/components/push/platforms/android/app-ui/TextAlertNotification/TextAlertNotification.css
+++ b/src/internal/components/push/platforms/android/app-ui/TextAlertNotification/TextAlertNotification.css
@@ -31,6 +31,12 @@
     width: 100%;
 }
 
+.notificare .notificare__push__android__alert__app-ui__no-app-icon-svg {
+    height: 112%;
+    width: 112%;
+    display: block;
+}
+
 .notificare .notificare__push__android__alert__app-ui__header {
     display: flex;
     align-items: center;

--- a/src/internal/components/push/platforms/android/app-ui/TextAlertNotification/TextAlertNotification.css
+++ b/src/internal/components/push/platforms/android/app-ui/TextAlertNotification/TextAlertNotification.css
@@ -32,9 +32,8 @@
 }
 
 .notificare .notificare__push__android__alert__app-ui__no-app-icon-svg {
-    height: 112%;
-    width: 112%;
-    display: block;
+    height: 100%;
+    width: 100%;
 }
 
 .notificare .notificare__push__android__alert__app-ui__header {

--- a/src/internal/components/push/platforms/android/app-ui/TextAlertNotification/TextAlertNotification.tsx
+++ b/src/internal/components/push/platforms/android/app-ui/TextAlertNotification/TextAlertNotification.tsx
@@ -1,4 +1,5 @@
 import { FormattedMessage } from 'react-intl';
+import NoAppIcon from '~/assets/no-app-icon.svg';
 import { useApplication } from '~/internal/context/application';
 import { NotificareNotificationSchema } from '~/internal/schemas/notificare-notification';
 import { hasActions } from '~/internal/utils/push-previews/notification';
@@ -17,11 +18,15 @@ export function TextAlertNotification({ notification }: TextAlertNotificationPro
       <div className="notificare__push__android__alert__app-ui__wrapper">
         <div className="notificare__push__android__alert__app-ui__header">
           <div className="notificare__push__android__alert__app-ui__app-icon">
-            <img
-              className="notificare__push__android__alert__app-ui__app-icon-image"
-              alt="App icon"
-              src={application.websitePushConfig.icon}
-            />
+            {application.icon ? (
+              <img
+                className="notificare__push__android__alert__app-ui__app-icon-image"
+                alt="App icon"
+                src={application.icon}
+              />
+            ) : (
+              <NoAppIcon className="notificare__push__android__alert__app-ui__no-app-icon-svg" />
+            )}
           </div>
           <p className="notificare__push__android__alert__app-ui__title">
             {notification.title || application.name}

--- a/src/internal/components/push/platforms/android/lock-screen/LockScreenNotification.css
+++ b/src/internal/components/push/platforms/android/lock-screen/LockScreenNotification.css
@@ -34,9 +34,8 @@
 }
 
 .notificare .notificare__push__android__lock-screen__no-app-icon-svg {
-  height: 112%;
-  width: 112%;
-  display: block;
+  height: 100%;
+  width: 100%;
 }
 
 /* Text Content */

--- a/src/internal/components/push/platforms/android/lock-screen/LockScreenNotification.css
+++ b/src/internal/components/push/platforms/android/lock-screen/LockScreenNotification.css
@@ -33,6 +33,12 @@
   width: 100%;
 }
 
+.notificare .notificare__push__android__lock-screen__no-app-icon-svg {
+  height: 112%;
+  width: 112%;
+  display: block;
+}
+
 /* Text Content */
 
 .notificare .notificare__push__android__lock-screen__text-content {

--- a/src/internal/components/push/platforms/android/lock-screen/LockScreenNotification.tsx
+++ b/src/internal/components/push/platforms/android/lock-screen/LockScreenNotification.tsx
@@ -1,4 +1,5 @@
 import { FormattedMessage } from 'react-intl';
+import NoAppIcon from '~/assets/no-app-icon.svg';
 import { useApplication } from '~/internal/context/application';
 import { NotificareNotificationSchema } from '~/internal/schemas/notificare-notification';
 import { hasFirstAttachment } from '~/internal/utils/push-previews/notification';
@@ -15,11 +16,15 @@ export function LockScreenNotification({ notification, expanded }: AndroidLockSc
       data-testid="android-lock-screen-notification"
     >
       <div className="notificare__push__android__lock-screen__app-icon">
-        <img
-          className="notificare__push__android__lock-screen__app-icon-image"
-          alt="App icon"
-          src={application.websitePushConfig.icon}
-        />
+        {application.icon ? (
+          <img
+            className="notificare__push__android__lock-screen__app-icon-image"
+            alt="App icon"
+            src={application.icon}
+          />
+        ) : (
+          <NoAppIcon className="notificare__push__android__lock-screen__no-app-icon-svg " />
+        )}
       </div>
       <div className="notificare__push__android__lock-screen__text-content">
         <div className="notificare__push__android__lock-screen__text-content-top">

--- a/src/internal/components/push/platforms/ios/lock-screen/LockScreenNotification.css
+++ b/src/internal/components/push/platforms/ios/lock-screen/LockScreenNotification.css
@@ -34,6 +34,12 @@
     width: 100%;
 }
 
+.notificare .notificare__push__ios__lock-screen__no-app-icon-svg {
+    height: 112%;
+    width: 112%;
+    display: block;
+}
+
 /*  Text Content */
 
 .notificare .notificare__push__ios__lock-screen__text-content {

--- a/src/internal/components/push/platforms/ios/lock-screen/LockScreenNotification.css
+++ b/src/internal/components/push/platforms/ios/lock-screen/LockScreenNotification.css
@@ -35,9 +35,8 @@
 }
 
 .notificare .notificare__push__ios__lock-screen__no-app-icon-svg {
-    height: 112%;
-    width: 112%;
-    display: block;
+    height: 100%;
+    width: 100%;
 }
 
 /*  Text Content */

--- a/src/internal/components/push/platforms/ios/lock-screen/LockScreenNotification.tsx
+++ b/src/internal/components/push/platforms/ios/lock-screen/LockScreenNotification.tsx
@@ -1,4 +1,5 @@
 import { FormattedMessage } from 'react-intl';
+import NoAppIcon from '~/assets/no-app-icon.svg';
 import { useApplication } from '~/internal/context/application';
 import { NotificareNotificationSchema } from '~/internal/schemas/notificare-notification';
 import { hasFirstAttachment } from '~/internal/utils/push-previews/notification';
@@ -13,11 +14,15 @@ export function LockScreenNotification({ notification, expanded }: IOSLockScreen
     <div className="notificare__push__ios__lock-screen" data-testid="ios-lock-screen-notification">
       <div className="notificare__push__ios__lock-screen__main-content">
         <div className="notificare__push__ios__lock-screen__app-icon">
-          <img
-            className="notificare__push__ios__lock-screen__app-icon-image"
-            alt="App icon"
-            src={application.websitePushConfig.icon}
-          />
+          {application.icon ? (
+            <img
+              className="notificare__push__ios__lock-screen__app-icon-image"
+              alt="App icon"
+              src={application.icon}
+            />
+          ) : (
+            <NoAppIcon className="notificare__push__ios__lock-screen__no-app-icon-svg" />
+          )}
         </div>
         <div className="notificare__push__ios__lock-screen__text-content">
           <div className="notificare__push__ios__lock-screen__title-and-time">

--- a/src/internal/components/push/platforms/web/app-ui/mobile/WebMobileAppUINotification.css
+++ b/src/internal/components/push/platforms/web/app-ui/mobile/WebMobileAppUINotification.css
@@ -42,10 +42,9 @@
     width: 100%;
 }
 
-.notificare .notificare__web__phone__app-ui__app-icon-svg {
-    width: 112%;
-    height: 112%;
-    display: block;
+.notificare .notificare__web__phone__app-ui__no-app-icon-svg {
+    height: 100%;
+    width: 100%;
 }
 
 .notificare .notificare__web__phone__app-ui__app-name {

--- a/src/internal/components/push/platforms/web/app-ui/mobile/WebMobileAppUINotification.css
+++ b/src/internal/components/push/platforms/web/app-ui/mobile/WebMobileAppUINotification.css
@@ -29,9 +29,23 @@
 }
 
 .notificare .notificare__web__phone__app-ui__app-icon {
+    display: flex;
+    justify-content: center;
+    align-items: center;
     border-radius: 4px;
     height: 32px;
     width: 32px;
+    overflow: hidden;
+}
+
+.notificare .notificare__web__phone__app-ui__app-icon-image {
+    width: 100%;
+}
+
+.notificare .notificare__web__phone__app-ui__app-icon-svg {
+    width: 112%;
+    height: 112%;
+    display: block;
 }
 
 .notificare .notificare__web__phone__app-ui__app-name {

--- a/src/internal/components/push/platforms/web/app-ui/mobile/WebMobileAppUINotification.tsx
+++ b/src/internal/components/push/platforms/web/app-ui/mobile/WebMobileAppUINotification.tsx
@@ -10,9 +10,7 @@ import { WebViewNotification } from './WebViewNotification/WebViewNotification';
 
 import './WebMobileAppUINotification.css';
 
-export function WebMobileAppUINotification({
-  notification,
-}: WebMobileAppUIProps) {
+export function WebMobileAppUINotification({ notification }: WebMobileAppUIProps) {
   const application = useApplication();
 
   if (
@@ -29,7 +27,7 @@ export function WebMobileAppUINotification({
           <div className="notificare__web__phone__app-ui__header">
             <img
               className="notificare__web__phone__app-ui__app-icon"
-              src={application.websitePushConfig.icon}
+              src={application.websitePushConfig.icon || 'src/assets/no-app-icon.svg'}
               alt="App icon"
             />
             <p className="notificare__web__phone__app-ui__app-name">{application.name}</p>

--- a/src/internal/components/push/platforms/web/app-ui/mobile/WebMobileAppUINotification.tsx
+++ b/src/internal/components/push/platforms/web/app-ui/mobile/WebMobileAppUINotification.tsx
@@ -34,7 +34,7 @@ export function WebMobileAppUINotification({ notification }: WebMobileAppUIProps
                   alt="App icon"
                 />
               ) : (
-                <NoAppIcon className="notificare__web__phone__app-ui__app-icon-svg" />
+                <NoAppIcon className="notificare__web__phone__app-ui__no-app-icon-svg" />
               )}
             </div>
 

--- a/src/internal/components/push/platforms/web/app-ui/mobile/WebMobileAppUINotification.tsx
+++ b/src/internal/components/push/platforms/web/app-ui/mobile/WebMobileAppUINotification.tsx
@@ -1,3 +1,4 @@
+import NoAppIcon from '~/assets/no-app-icon.svg';
 import ThinXMarkIcon from '~/assets/thin-x-mark.svg';
 import { MapRichContent } from '~/internal/components/push/platforms/shared/MapRichContent/MapRichContent';
 import { VideoRichContent } from '~/internal/components/push/platforms/shared/VideoRichContent/VideoRichContent';
@@ -25,11 +26,18 @@ export function WebMobileAppUINotification({ notification }: WebMobileAppUIProps
       <div className="notificare__web__phone__app-ui">
         <div className="notificare__web__phone__app-ui__background">
           <div className="notificare__web__phone__app-ui__header">
-            <img
-              className="notificare__web__phone__app-ui__app-icon"
-              src={application.websitePushConfig.icon || 'src/assets/no-app-icon.svg'}
-              alt="App icon"
-            />
+            <div className="notificare__web__phone__app-ui__app-icon">
+              {application.websitePushConfig.icon ? (
+                <img
+                  className="notificare__web__phone__app-ui__app-icon-image"
+                  src={application.websitePushConfig.icon}
+                  alt="App icon"
+                />
+              ) : (
+                <NoAppIcon className="notificare__web__phone__app-ui__app-icon-svg" />
+              )}
+            </div>
+
             <p className="notificare__web__phone__app-ui__app-name">{application.name}</p>
             <button className="notificare__web__phone__app-ui__close-button">
               <ThinXMarkIcon className="notificare__web__phone__app-ui__close-button-icon" />

--- a/src/internal/components/push/platforms/web/lockscreen/WebMacOSNotification.tsx
+++ b/src/internal/components/push/platforms/web/lockscreen/WebMacOSNotification.tsx
@@ -120,7 +120,9 @@ export function WebMacOSNotification({ notification }: WebPushProps) {
             {notification.title || application.name}
           </p>
           <p className="notificare__push__web__desktop__lock-screen__text notificare__push__web__desktop__lock-screen__text--domain">
-            {extractDomain(application.websitePushConfig.allowedDomains[0])}
+            {application.websitePushConfig.allowedDomains.length > 0
+              ? extractDomain(application.websitePushConfig.allowedDomains[0])
+              : 'example.com'}
           </p>
           <p
             ref={messageRef}

--- a/src/internal/hooks/application-loader.ts
+++ b/src/internal/hooks/application-loader.ts
@@ -5,9 +5,10 @@ import { ApplicationInfo } from '~/internal/types/application-info';
 
 const DEFAULT_APPLICATION = {
   name: 'My app',
+  icon: undefined,
   androidPackageName: 'com.example.app',
   websitePushConfig: {
-    icon: 'https://avatars.githubusercontent.com/u/1728060?s=200&v=4',
+    icon: undefined,
     allowedDomains: ['https://my-app.com/'],
   },
 } satisfies ApplicationInfo;

--- a/src/internal/network/requests/application.ts
+++ b/src/internal/network/requests/application.ts
@@ -15,9 +15,12 @@ export async function fetchApplication(id: string, serviceKey: string): Promise<
   const { application } = await response.json();
   return {
     name: application.name,
+    icon: application.icon,
     androidPackageName: application.androidPackageName,
     websitePushConfig: application.websitePushConfig && {
-      icon: calculateCompleteIconUrl(application.websitePushConfig.icon),
+      icon: application.websitePushConfig.icon
+        ? calculateCompleteIconUrl(application.websitePushConfig.icon)
+        : undefined,
       allowedDomains: application.websitePushConfig.allowedDomains,
     },
   };

--- a/src/internal/types/application-info.ts
+++ b/src/internal/types/application-info.ts
@@ -1,10 +1,11 @@
 export type ApplicationInfo = {
   name: string;
-  androidPackageName: string; // TODO: this can be null or undefined.
+  icon?: string;
+  androidPackageName?: string;
   websitePushConfig: ApplicationInfoWebsitePushConfig;
-}
+};
 
 export interface ApplicationInfoWebsitePushConfig {
-  icon: string;
+  icon?: string;
   allowedDomains: string[];
 }


### PR DESCRIPTION
- Use default SVG icon when the icon is not configured (both Android/iOS and Web)
- Use default domain when allowedDomains is empty
- Set androidPackageName, icon and websitePushConfig.icon as optional properties (application)
- Encode URL and remove 'hl' query parameter in Android rate preview