### PR TITLE
Webshot request fixes and improvements

### DIFF
--- a/src/components/NotificareNotificationPreview/tests/NotificareNotificationPreview.test.tsx
+++ b/src/components/NotificareNotificationPreview/tests/NotificareNotificationPreview.test.tsx
@@ -2739,14 +2739,7 @@ describe('NotificareNotificationPreview', () => {
     );
 
     // Advance setTimeout (debounce)
-    await act(async () => {
-      jest.advanceTimersByTime(3000);
-    });
-
-    // Advance setInterval
-    await act(async () => {
-      jest.advanceTimersByTime(3000);
-    });
+    act(() => jest.advanceTimersByTime(500));
 
     // ASSERT
     const webshot = await screen.findByTestId('webshot');


### PR DESCRIPTION
Changes:

- check webshot status immediately when a new id is set
- avoid checking status simultaneously
- ignore old request results (bug)
- update successfull webshot test